### PR TITLE
✨ feat: add queue option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Message expiration time, after which an error will be thrown.
 
 Either `0` (disabled), `1` (error), `2` (warn), `3` (info), `4` (debug), `5` (log)
 
+#### queue
+- Type: `Boolean`
+- Default: `false`
+
+If `true`, messages will be queued until the target window is ready to receive them.
+Needs to also be set inside the target window to trigger a ready event.
 
 ## Documentation
 

--- a/examples/child.js
+++ b/examples/child.js
@@ -1,80 +1,82 @@
-import { on, setGlobalOptions } from '@poool/buddy';
+import { on } from '@poool/buddy';
 
-setGlobalOptions({ queue: true });
+on('test:messaging', () => {
+  return 'response:messaging';
+}, { source: window.parent });
+
+on('test:wrongWindow', () => {
+  return 'response:wrongWindow';
+}, { source: window });
+
+on('test:serializeArray', e => {
+  return e.data;
+}, { source: window.parent });
+
+on('test:serializeMethod', e => {
+  e.data.serializeMethod();
+}, { source: window.parent });
+
+on('test:serializePromise', async e => {
+  const result = await e.data();
+
+  return result;
+}, { source: window.parent });
+
+on('test:serializeUnknown', async e => {
+  return e.data;
+}, { source: window.parent });
+
+on('test:unserializeFunctionsAndObjects', async e => {
+  const result = await e.data;
+
+  return result;
+}, { source: window.parent });
+
+on('test:parentMethodReturnValue', async e => {
+  const result = await e.data.parentCallback();
+
+  return result;
+}, { source: window.parent });
+
+on('test:parentMethodCalledTwice', async e => {
+  await e.data.callback();
+  await e.data.callback();
+}, { source: window.parent });
+
+on('test:noTarget', async e => {
+  e.data.callback();
+}, { source: window.parent });
+
+on('test:nestedArrayResponseFromChild', async e => {
+  await e.data.callback('init', { callback: () => 'response from child' });
+}, { source: window.parent });
+
+on('test:primitiveTypes', e => {
+  return e.data;
+}, { source: window.parent });
+
+on('test:back-and-forth', async e => {
+  const res = await e.data.callback();
+
+  return JSON.stringify(res);
+}, { source: window.parent });
+
+on('test:throw', async e => {
+  return e.data.promiseThatThrows();
+}, { source: window.parent });
+
+on('test:throw-deep', async e => {
+  try {
+    await e.data.promiseThatThrows();
+
+    return 'success';
+  } catch (er) {
+    return er.message;
+  }
+}, { source: window.parent });
 
 setTimeout(() => {
-  on('test:messaging', () => {
-    return 'response:messaging';
-  }, { source: window.parent });
-
-  on('test:wrongWindow', () => {
-    return 'response:wrongWindow';
-  }, { source: window });
-
-  on('test:serializeArray', e => {
-    return e.data;
-  }, { source: window.parent });
-
-  on('test:serializeMethod', e => {
-    e.data.serializeMethod();
-  }, { source: window.parent });
-
-  on('test:serializePromise', async e => {
-    const result = await e.data();
-
-    return result;
-  }, { source: window.parent });
-
-  on('test:serializeUnknown', async e => {
-    return e.data;
-  }, { source: window.parent });
-
-  on('test:unserializeFunctionsAndObjects', async e => {
-    const result = await e.data;
-
-    return result;
-  }, { source: window.parent });
-
-  on('test:parentMethodReturnValue', async e => {
-    const result = await e.data.parentCallback();
-
-    return result;
-  }, { source: window.parent });
-
-  on('test:parentMethodCalledTwice', async e => {
-    await e.data.callback();
-    await e.data.callback();
-  }, { source: window.parent });
-
-  on('test:noTarget', async e => {
-    e.data.callback();
-  }, { source: window.parent });
-
-  on('test:nestedArrayResponseFromChild', async e => {
-    await e.data.callback('init', { callback: () => 'response from child' });
-  }, { source: window.parent });
-
-  on('test:primitiveTypes', e => {
-    return e.data;
-  }, { source: window.parent });
-
-  on('test:back-and-forth', async e => {
-    const res = await e.data.callback();
-
-    return JSON.stringify(res);
-  }, { source: window.parent });
-
-  on('test:throw', async e => {
-    return e.data.promiseThatThrows();
-  }, { source: window.parent });
-
-  on('test:throw-deep', async e => {
-    try {
-      await e.data.promiseThatThrows();
-
-      return 'success';
-    } catch (er) {
-      return er.message;
-    }
-  }, { source: window.parent });
+  on('test:delayed', () => {
+    return 'response:delayed';
+  }, { queue: true, source: window.parent });
 }, 100);

--- a/examples/child.js
+++ b/examples/child.js
@@ -1,76 +1,80 @@
-import { on } from '@poool/buddy';
+import { on, setGlobalOptions } from '@poool/buddy';
 
-on('test:messaging', () => {
-  return 'response:messaging';
-}, { source: window.parent });
+setGlobalOptions({ queue: true });
 
-on('test:wrongWindow', () => {
-  return 'response:wrongWindow';
-}, { source: window });
+setTimeout(() => {
+  on('test:messaging', () => {
+    return 'response:messaging';
+  }, { source: window.parent });
 
-on('test:serializeArray', e => {
-  return e.data;
-}, { source: window.parent });
+  on('test:wrongWindow', () => {
+    return 'response:wrongWindow';
+  }, { source: window });
 
-on('test:serializeMethod', e => {
-  e.data.serializeMethod();
-}, { source: window.parent });
+  on('test:serializeArray', e => {
+    return e.data;
+  }, { source: window.parent });
 
-on('test:serializePromise', async e => {
-  const result = await e.data();
+  on('test:serializeMethod', e => {
+    e.data.serializeMethod();
+  }, { source: window.parent });
 
-  return result;
-}, { source: window.parent });
+  on('test:serializePromise', async e => {
+    const result = await e.data();
 
-on('test:serializeUnknown', async e => {
-  return e.data;
-}, { source: window.parent });
+    return result;
+  }, { source: window.parent });
 
-on('test:unserializeFunctionsAndObjects', async e => {
-  const result = await e.data;
+  on('test:serializeUnknown', async e => {
+    return e.data;
+  }, { source: window.parent });
 
-  return result;
-}, { source: window.parent });
+  on('test:unserializeFunctionsAndObjects', async e => {
+    const result = await e.data;
 
-on('test:parentMethodReturnValue', async e => {
-  const result = await e.data.parentCallback();
+    return result;
+  }, { source: window.parent });
 
-  return result;
-}, { source: window.parent });
+  on('test:parentMethodReturnValue', async e => {
+    const result = await e.data.parentCallback();
 
-on('test:parentMethodCalledTwice', async e => {
-  await e.data.callback();
-  await e.data.callback();
-}, { source: window.parent });
+    return result;
+  }, { source: window.parent });
 
-on('test:noTarget', async e => {
-  e.data.callback();
-}, { source: window.parent });
+  on('test:parentMethodCalledTwice', async e => {
+    await e.data.callback();
+    await e.data.callback();
+  }, { source: window.parent });
 
-on('test:nestedArrayResponseFromChild', async e => {
-  await e.data.callback('init', { callback: () => 'response from child' });
-}, { source: window.parent });
+  on('test:noTarget', async e => {
+    e.data.callback();
+  }, { source: window.parent });
 
-on('test:primitiveTypes', e => {
-  return e.data;
-}, { source: window.parent });
+  on('test:nestedArrayResponseFromChild', async e => {
+    await e.data.callback('init', { callback: () => 'response from child' });
+  }, { source: window.parent });
 
-on('test:back-and-forth', async e => {
-  const res = await e.data.callback();
+  on('test:primitiveTypes', e => {
+    return e.data;
+  }, { source: window.parent });
 
-  return JSON.stringify(res);
-}, { source: window.parent });
+  on('test:back-and-forth', async e => {
+    const res = await e.data.callback();
 
-on('test:throw', async e => {
-  return e.data.promiseThatThrows();
-}, { source: window.parent });
+    return JSON.stringify(res);
+  }, { source: window.parent });
 
-on('test:throw-deep', async e => {
-  try {
-    await e.data.promiseThatThrows();
+  on('test:throw', async e => {
+    return e.data.promiseThatThrows();
+  }, { source: window.parent });
 
-    return 'success';
-  } catch (er) {
-    return er.message;
-  }
-}, { source: window.parent });
+  on('test:throw-deep', async e => {
+    try {
+      await e.data.promiseThatThrows();
+
+      return 'success';
+    } catch (er) {
+      return er.message;
+    }
+  }, { source: window.parent });
+}, 100);

--- a/examples/index.html
+++ b/examples/index.html
@@ -5,6 +5,7 @@
     <title>Parent</title>
   </head>
   <body>
+    <div>(if this example does not work on refresh, disable cache from your browser settings)</div>
     <h1>Parent</h1>
     <iframe id="child" src="./child.html"></iframe>
   </body>

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,7 +1,5 @@
-import { send, setGlobalOptions } from '@poool/buddy';
+import { send } from '@poool/buddy';
 import sinon from 'sinon';
-
-setGlobalOptions({ queue: true });
 
 const createElement = (id, content) => {
   const elmt = document.createElement('div');
@@ -143,6 +141,11 @@ const exec = async () => {
   const throwsDeepResult = await send(contentWindow,
     'test:throw-deep', { promiseThatThrows: throwsDeep });
   createElement('throw-deep', throwsDeepResult);
+
+  // test:delayed
+  const delayedResult = await send(contentWindow, 'test:delayed', {},
+    { queue: true });
+  createElement('delayed', delayedResult);
 };
 
 if (frame.contentWindow) {

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,5 +1,7 @@
-import { send } from '@poool/buddy';
+import { send, setGlobalOptions } from '@poool/buddy';
 import sinon from 'sinon';
+
+setGlobalOptions({ queue: true });
 
 const createElement = (id, content) => {
   const elmt = document.createElement('div');

--- a/src/lib.js
+++ b/src/lib.js
@@ -209,12 +209,13 @@ export const send = (target, name, data, options = {}) => {
     };
 
     if (pingBack) {
+      const timeoutErr = new Error('timeout');
       sendTimeout = setTimeout(() => {
         queueHandler && queueHandler.off();
         didTimeout = true;
         error(options,
           `Target window did not respond in time, aborting (event: ${name})`);
-        reject(new Error('timeout'));
+        reject(timeoutErr);
       }, timeout);
 
       const handler = on(event.bid, e => {

--- a/src/lib.js
+++ b/src/lib.js
@@ -61,7 +61,7 @@ const serialize = (
         ...rest,
         pingBack: false,
       });
-    }, { source: target, ...rest, pingBack: false });
+    }, { source: target, ...rest, pingBack: false, queue: false });
 
     return { bid: methodId, type: 'promise' };
   }
@@ -84,7 +84,7 @@ const serialize = (
         ...rest,
         pingBack: false,
       });
-    }, { source: target, ...rest, pingBack: false });
+    }, { source: target, ...rest, pingBack: false, queue: false });
 
     return { bid: methodId, type: 'function' };
   }
@@ -143,7 +143,7 @@ const unserialize = (
             e.data);
 
           resolve(e.data);
-        }, { ...options, onError: reject, pingBack: false });
+        }, { ...options, onError: reject, pingBack: false, queue: false });
 
         debug(options,
           'Sending serialized method params to parent',
@@ -153,7 +153,7 @@ const unserialize = (
 
         send(source, data.bid, {
           args: serialize(args, { target: source, origin, ...rest }),
-        }, { target: source, origin, ...rest, pingBack: false });
+        }, { target: source, origin, ...rest, pingBack: false, queue: false });
       });
     };
   }
@@ -187,6 +187,7 @@ export const send = (target, name, data, options = {}) => {
   }
 
   let sendTimeout;
+  let queueHandler;
   let didTimeout = false;
 
   return new Promise((resolve, reject) => {
@@ -209,6 +210,7 @@ export const send = (target, name, data, options = {}) => {
 
     if (pingBack) {
       sendTimeout = setTimeout(() => {
+        queueHandler && queueHandler.off();
         didTimeout = true;
         error(options,
           `Target window did not respond in time, aborting (event: ${name})`);
@@ -217,6 +219,7 @@ export const send = (target, name, data, options = {}) => {
 
       const handler = on(event.bid, e => {
         handler.off();
+        queueHandler && queueHandler.off();
 
         if (!didTimeout) {
           clearTimeout(sendTimeout);
@@ -252,6 +255,15 @@ export const send = (target, name, data, options = {}) => {
 
     info(options,
       `Sending message to target window (event: ${name}) -->`, parsedData);
+
+    if (options.queue) {
+      info(options, 'Queueing message in case target window is not ready');
+      queueHandler = on('target:loaded', () => {
+        queueHandler && queueHandler.off();
+        target.postMessage(parsedData, origin);
+      }, { source: target, origin, ...rest, queue: false, pingBack: false });
+    }
+
     target.postMessage(parsedData, origin);
   });
 };
@@ -280,14 +292,14 @@ export const on = (name, fn, options = {}) => {
 
     if (source && e.source !== source) {
       send(e.source, event.bid, { error: 'source' },
-        { ...rest, origin: e.origin, pingBack: false });
+        { ...rest, origin: e.origin, pingBack: false, queue: false });
 
       return;
     }
 
     if (origin && origin !== '*' && e.origin !== origin) {
       send(e.source, event.bid, { error: 'origin' },
-        { ...rest, origin: e.origin, pingBack: false });
+        { ...rest, origin: e.origin, pingBack: false, queue: false });
 
       return;
     }
@@ -325,6 +337,7 @@ export const on = (name, fn, options = {}) => {
           ...rest,
           origin: e.origin,
           pingBack: false,
+          queue: false,
         });
       }
     }).catch(er => {
@@ -336,12 +349,19 @@ export const on = (name, fn, options = {}) => {
           ...rest,
           origin: e.origin,
           pingBack: false,
+          queue: false,
         });
       }
     });
   };
 
   window.addEventListener('message', handler, false);
+
+  if (options.queue) {
+    send(source, 'target:loaded', {}, {
+      ...rest, pingBack: false, queue: false,
+    });
+  }
 
   return {
     off: () => {

--- a/src/options.js
+++ b/src/options.js
@@ -1,6 +1,7 @@
 export const globalOptions = {
   timeout: 5000,
   logLevel: 1,
+  queue: false,
 };
 
 export const setGlobalOptions = options => {

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -122,6 +122,11 @@ describe('buddy', () => {
       .toBe('custom_deep_error');
   });
 
+  it('should correctly handle delayed handlers', async () => {
+    expect(await getResult('#delayed'))
+      .toBe('response:delayed');
+  });
+
   afterAll(async () => {
     try {
       const coverage = await page.coverage.stopJSCoverage();


### PR DESCRIPTION
On recent browsers (although the problem is only noticeable on chrome), cache loading order messes up events registering & messages when the target window/frame loads after the parent has already sent messages (the problem does not apply on messages sent after an iframe or a new window is manually loaded/opened).

This PR adds an option called `queue` that, when enabled on the parent will register a `target:loaded` event handler to queue messages in case the child registers its handlers too soon, and when enabled on the child will send that same `target:loaded` event to drain the parent messages queue, ensuring messages are not sent into oblivion.

The best way I found to test this was to delay child event handlers registration by 100ms to let the parent try to send the messages (into the void), to finally let the child trigger the messages queue and correctly receive the said messages. If anyone has a better/more accurate way to test this, that'd be really appreciated ❤️ 