### PR TITLE
🐛fix: abort queued events from being sent twice

### DIFF
--- a/examples/child.ts
+++ b/examples/child.ts
@@ -131,3 +131,10 @@ setTimeout(() => {
     return 'response:delayed';
   }, { queue: true, source: window.parent });
 }, 100);
+
+let counter = 0;
+on('test:aborted-event', () => {
+  counter++;
+
+  return 'response:aborted-event' + counter;
+}, { source: window.parent, origin: '*' });

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -205,6 +205,11 @@ const exec = async () => {
   });
   const wsResult = await sendWsMessage();
   createElement('ws', wsResult);
+
+  const abortedSend = await send(contentWindow, 'test:aborted-event', {}, {
+    queue: true, timeout: 700, origin: '*', source: window.parent,
+  });
+  createElement('queue-abort', abortedSend);
 };
 
 if (frame.contentWindow) {

--- a/examples/index.ts
+++ b/examples/index.ts
@@ -207,7 +207,7 @@ const exec = async () => {
   createElement('ws', wsResult);
 
   const abortedSend = await send(contentWindow, 'test:aborted-event', {}, {
-    queue: true, timeout: 700, origin: '*', source: window.parent,
+    queue: true,
   });
   createElement('queue-abort', abortedSend);
 };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -291,7 +291,6 @@ export const send = (
   data: BuddySerializableData | BuddySerializedData,
   options: BuddyOptions = {}
 ): Promise<BuddySerializableData> => {
-
   const controller = new AbortController();
 
   options = extendGlobalOptions(options);
@@ -399,7 +398,7 @@ export const send = (
 
     sendMessage(target, parsedData, { origin, signal: controller.signal });
 
-    if(options.queue) {
+    if (options.queue) {
       controller.abort();
     }
   });
@@ -554,10 +553,10 @@ const sendMessage = (
   opts: BuddyOptions = {}
 ) => {
   if (typeof (target as Window).postMessage === 'function') {
-    if(opts.signal.aborted) {
+    if (opts.signal.aborted) {
       debug(
         opts,
-        'Message in queue was aborted, not sending, because already sent.'
+        'Message already sent, ignoring'
       );
 
       return;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -292,6 +292,8 @@ export const send = (
   options: BuddyOptions = {}
 ): Promise<BuddySerializableData> => {
 
+  const abort = new AbortController();
+
   options = extendGlobalOptions(options);
   const { origin = '*', timeout = 5000, pingBack = true, ...rest } = options;
 
@@ -378,7 +380,6 @@ export const send = (
 
     info(options,
       `Sending message to target window (event: ${name}) -->`, parsedData);
-    const abort = new AbortController();
 
     if (options.queue) {
       info(options, 'Queueing message in case target window is not ready');
@@ -397,7 +398,10 @@ export const send = (
     }
 
     sendMessage(target, parsedData, { origin, signal: abort.signal });
-    abort.abort();
+
+    if(options.queue) {
+      abort.abort();
+    }
   });
 };
 
@@ -551,6 +555,11 @@ const sendMessage = (
 ) => {
   if (typeof (target as Window).postMessage === 'function') {
     if(opts.signal.aborted) {
+      info(
+        opts,
+        'Message in queue was aborted, not sending, because already sent.'
+      );
+
       return;
     }
 

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -292,7 +292,7 @@ export const send = (
   options: BuddyOptions = {}
 ): Promise<BuddySerializableData> => {
 
-  const abort = new AbortController();
+  const controller = new AbortController();
 
   options = extendGlobalOptions(options);
   const { origin = '*', timeout = 5000, pingBack = true, ...rest } = options;
@@ -385,8 +385,8 @@ export const send = (
       info(options, 'Queueing message in case target window is not ready');
       queueHandler = on('target:loaded', () => {
         queueHandler?.off?.();
-        sendMessage(target, parsedData, { origin, signal: abort.signal });
-        abort.abort();
+        sendMessage(target, parsedData, { origin, signal: controller.signal });
+        controller.abort();
       }, {
         source: target,
         origin,
@@ -397,10 +397,10 @@ export const send = (
       });
     }
 
-    sendMessage(target, parsedData, { origin, signal: abort.signal });
+    sendMessage(target, parsedData, { origin, signal: controller.signal });
 
     if(options.queue) {
-      abort.abort();
+      controller.abort();
     }
   });
 };
@@ -555,7 +555,7 @@ const sendMessage = (
 ) => {
   if (typeof (target as Window).postMessage === 'function') {
     if(opts.signal.aborted) {
-      info(
+      debug(
         opts,
         'Message in queue was aborted, not sending, because already sent.'
       );

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -45,6 +45,7 @@ export const serialize = (
   data: BuddySerializableData | BuddySerializedData,
   options: BuddyOptions = {},
 ): BuddySerializedData => {
+
   options = extendGlobalOptions(options);
   const { target, origin, serializers, ...rest } = options;
 
@@ -290,6 +291,7 @@ export const send = (
   data: BuddySerializableData | BuddySerializedData,
   options: BuddyOptions = {}
 ): Promise<BuddySerializableData> => {
+
   options = extendGlobalOptions(options);
   const { origin = '*', timeout = 5000, pingBack = true, ...rest } = options;
 
@@ -376,12 +378,14 @@ export const send = (
 
     info(options,
       `Sending message to target window (event: ${name}) -->`, parsedData);
+    const abort = new AbortController();
 
     if (options.queue) {
       info(options, 'Queueing message in case target window is not ready');
       queueHandler = on('target:loaded', () => {
         queueHandler?.off?.();
-        sendMessage(target, parsedData, { origin });
+        sendMessage(target, parsedData, { origin, signal: abort.signal });
+        abort.abort();
       }, {
         source: target,
         origin,
@@ -392,7 +396,8 @@ export const send = (
       });
     }
 
-    sendMessage(target, parsedData, { origin });
+    sendMessage(target, parsedData, { origin, signal: abort.signal });
+    abort.abort();
   });
 };
 
@@ -545,6 +550,10 @@ const sendMessage = (
   opts: BuddyOptions = {}
 ) => {
   if (typeof (target as Window).postMessage === 'function') {
+    if(opts.signal.aborted) {
+      return;
+    }
+
     (target as Window).postMessage(data, opts.origin);
   } else {
     (target as WebSocket | WebSocketConnection).send(data);

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -357,7 +357,6 @@ export const send = (
         ...rest,
         source: target,
         origin,
-        queue: false,
         onError: reject,
         pingBack: false,
         offSwitches: options.offSwitches,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -354,9 +354,10 @@ export const send = (
           resolve(e.data as BuddySerializableData);
         }
       }, {
+        ...rest,
         source: target,
         origin,
-        ...rest,
+        queue: false,
         onError: reject,
         pingBack: false,
         offSwitches: options.offSwitches,
@@ -388,9 +389,9 @@ export const send = (
         sendMessage(target, parsedData, { origin, signal: controller.signal });
         controller.abort();
       }, {
+        ...rest,
         source: target,
         origin,
-        ...rest,
         queue: false,
         pingBack: false,
         offSwitches: options.offSwitches,

--- a/src/options.ts
+++ b/src/options.ts
@@ -77,6 +77,8 @@ export declare interface BuddyOptions extends BuddyGlobalOptions {
 
   mode?: 'iframe' | 'websocket' | 'websocket-server';
 
+  signal?: AbortSignal;
+
   /**
    * Callback to be called when a message produces an error
    * (even when unserializing data)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -151,7 +151,7 @@ describe('buddy', () => {
   });
 
   it('should abort message sending if it has already been sent', async () => {
-    expect(await getResult('#queue-abort')).toBe('true');
+    expect(await getResult('#queue-abort')).toBe('response:aborted-event1');
   });
 
   afterAll(async () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -150,6 +150,10 @@ describe('buddy', () => {
     expect(await getResult('#ws')).toBe('test:ws');
   });
 
+  it('should abort message sending if it has already been sent', async () => {
+    expect(await getResult('#queue-abort')).toBe('true');
+  });
+
   afterAll(async () => {
     await devServer.teardown(servers);
     await browser.close();


### PR DESCRIPTION
When we deal with a `queued` event, we send a first event, that we assume it will not be listened by client (because it is not ready yet), and add a listener on `target:loaded`. The main problem is that if the client is ready at the same time we send event, it will be sent and listened twice.
@p3ol/wetf I need your help here